### PR TITLE
Fix build for c++20 in gcc-11

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -231,6 +231,7 @@ class Slice<T>::iterator final {
 public:
 #if __cplusplus >= 202002L
   using iterator_category = std::contiguous_iterator_tag;
+  using element_type = T;
 #else
   using iterator_category = std::random_access_iterator_tag;
 #endif


### PR DESCRIPTION
static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>) requires an associated element_type in gcc-11.2. As far as I can tell this is not true for the latest version hence why this wasn't failing... element_type comes from treating the iterator as a pointer and some static_assert that the pointer has a pointee type: https://gcc.gnu.org/onlinedocs/gcc-11.2.0/libstdc++/api/a00575_source.html line 119